### PR TITLE
Adding commands

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -25,3 +25,10 @@ type StringCmd interface {
 	Uint64() (uint64, error)
 	Val() string
 }
+
+type IntCmd interface {
+	Val() int64
+	String() string
+	Err() error
+	Result() (int64, error)
+}

--- a/observability.go
+++ b/observability.go
@@ -7,6 +7,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	"gopkg.in/redis.v3"
 )
 
 const (
@@ -137,7 +138,7 @@ func recordCall(ctx context.Context, method string, instanceName string) func(cm
 			}
 		)
 
-		if cmd.Err() != nil {
+		if cmd.Err() != nil && cmd.Err() != redis.Nil {
 			tags = append(tags, tag.Insert(GoRedisStatus, statusError))
 		} else {
 			tags = append(tags, tag.Insert(GoRedisStatus, statusOK))

--- a/wrapper.go
+++ b/wrapper.go
@@ -51,10 +51,11 @@ func (w *Wrapper) Incr(ctx context.Context, key string) (cmd IntCmd) {
 
 }
 
-func (w *Wrapper) Ping() (error, string) {
+func (w *Wrapper) Ping(ctx context.Context) (cmd StatusCmd) {
+	var recordCallFunc = recordCall(ctx, "go.redis.ping", w.instanceName)
+	defer func() {
+		recordCallFunc(cmd)
+	}()
 	res := w.client.Ping()
-	if res.Err() != nil {
-		return res.Err(), ""
-	}
-	return nil, res.String()
+	return res
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -40,3 +40,21 @@ func (w *Wrapper) Set(ctx context.Context, key string, value interface{}, expira
 	cmd = w.client.Set(key, value, expiration)
 	return
 }
+
+func (w *Wrapper) Incr(ctx context.Context, key string) (cmd IntCmd) {
+	var recordCallFunc = recordCall(ctx, "go.redis.incr", w.instanceName)
+	defer func() {
+		recordCallFunc(cmd)
+	}()
+	cmd = w.client.Incr(key)
+	return
+
+}
+
+func (w *Wrapper) Ping() error {
+	res := w.client.Ping()
+	if res.Err() != nil {
+		return res.Err()
+	}
+	return nil
+}

--- a/wrapper.go
+++ b/wrapper.go
@@ -51,10 +51,10 @@ func (w *Wrapper) Incr(ctx context.Context, key string) (cmd IntCmd) {
 
 }
 
-func (w *Wrapper) Ping() error {
+func (w *Wrapper) Ping() (error, string) {
 	res := w.client.Ping()
 	if res.Err() != nil {
-		return res.Err()
+		return res.Err(), ""
 	}
-	return nil
+	return nil, res.String()
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -56,6 +56,6 @@ func (w *Wrapper) Ping(ctx context.Context) (cmd StatusCmd) {
 	defer func() {
 		recordCallFunc(cmd)
 	}()
-	res := w.client.Ping()
-	return res
+	cmd = w.client.Ping()
+	return cmd
 }


### PR DESCRIPTION
Updated recordCall function in the observability.go file to except the redis.Nil error returned on a nil return. This fixes the issue of setting the status metric to ERROR when a nil value is returned from a get.

Added a Ping and Incr command to the Wrapper that allow us to use the wrapper to preform those needed actions. Ping returns a IntCmd, so I also implemented that struct in the commands.go file.