### PR TITLE
Added Decr Function

### DIFF
--- a/wrapper.go
+++ b/wrapper.go
@@ -51,6 +51,15 @@ func (w *Wrapper) Incr(ctx context.Context, key string) (cmd IntCmd) {
 
 }
 
+func (w *Wrapper) Decr(ctx context.Context, key string) (cmd IntCmd) {
+	var recordCallFunc = recordCall(ctx, "go.redis.decr", w.instanceName)
+	defer func() {
+		recordCallFunc(cmd)
+	}()
+	cmd = w.client.Decr(key)
+	return
+}
+
 func (w *Wrapper) Ping(ctx context.Context) (cmd StatusCmd) {
 	var recordCallFunc = recordCall(ctx, "go.redis.ping", w.instanceName)
 	defer func() {


### PR DESCRIPTION
This update will allow the redis `Decr()` function to be called through the wrapper.